### PR TITLE
Toast: Fix toast layout for RTL

### DIFF
--- a/core/res/res/layout/transient_notification.xml
+++ b/core/res/res/layout/transient_notification.xml
@@ -31,7 +31,7 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="-16dp"
         android:layout_marginStart="-16dp"
-        android:layout_toRightOf="@android:id/icon"
+        android:layout_toEndOf="@android:id/icon"
         android:layout_below="@android:id/icon"
         android:textAppearance="@style/TextAppearance.Toast"
         android:textColor="@color/bright_foreground_dark"


### PR DESCRIPTION
For RTL the toast would only show the icon badge due to the use of
layout_toRightOf instead of layout_toEndOf.

**This is serious bug for RTL users that actually prefer other roms because of this bug.**